### PR TITLE
rnd_next: skip the nonexistent tuples

### DIFF
--- a/ha_lineairdb.cc
+++ b/ha_lineairdb.cc
@@ -624,6 +624,7 @@ int ha_lineairdb::rnd_next(uchar* buf) {
   Field** field = table->field;
 
   if (keys.size() == 0) DBUG_RETURN(HA_ERR_END_OF_FILE);
+read_from_lineairdb:
   if (current_position == keys.size()) DBUG_RETURN(HA_ERR_END_OF_FILE);
 
   auto& tx         = get_db()->BeginTransaction();
@@ -632,7 +633,8 @@ int ha_lineairdb::rnd_next(uchar* buf) {
 
   if (read_buffer.first == nullptr) {
     get_db()->EndTransaction(tx, [&](auto s) { status = s; });
-    DBUG_RETURN(1);
+    current_position++;
+    goto read_from_lineairdb;
   }
 
   printf("%s\n", read_buffer.first);


### PR DESCRIPTION
When `rnd_next` gets the `nullptr` for a key, it means either
* nonexistence of the key is stored in lineairdb ( `Read` is executed but `Write` is not yet )
* it reaches the end of range scanning

This PR does not return ERROR but skips the key in the former cases.

# Before

<img width="834" alt="Screen Shot 2022-05-26 at 18 07 15" src="https://user-images.githubusercontent.com/1196079/170609889-6274a626-9d91-4e6e-88ef-926904001a07.png">


# After

<img width="823" alt="Screen Shot 2022-05-27 at 9 50 26" src="https://user-images.githubusercontent.com/1196079/170609961-ccf3b569-4463-4735-a315-ba4f7097ad62.png">

