### PR TITLE
Update firstCI.yml

### DIFF
--- a/.github/workflows/firstCI.yml
+++ b/.github/workflows/firstCI.yml
@@ -48,5 +48,5 @@ jobs:
         bin/mysqld --initialize --basedir=$(pwd) --datadir=$(pwd)/data;
         touch my.cnf;
         echo "[mysqld]\nbasedir=/home/runner/work/LineairDB-storage-engine/LineairDB-storage-engine/mysql-server/build\ndatadir=/home/runner/work/LineairDB-storage-engine/LineairDB-storage-engine/mysql-server/build/data" > my.cnf;
-        bin/mysqld --defaults-file=./my.cnf;
+        bin/mysqld --daemonize --defaults-file=./my.cnf;
         bats ../storage/lineairdb/tests/test.bats;


### PR DESCRIPTION
Current CI workflow (https://github.com/Tatzhiro/LineairDB-storage-engine/runs/6623836779?check_suite_focus=true) has suspended at `mysqld` and thus `bats` testing has not been executed.
It is because `bin/mysqld` is not daemonized (not forked to another process).
This PR add `—daemonize` option to `bin/mysqld` to fix this problem.


ref: https://dev.mysql.com/doc/refman/8.0/en/server-options.html