### PR TITLE
refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "terminal.integrated.env.osx": {
     "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin"
-  }
+  },
+  "search.followSymlinks": false
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(third_party/lineairdb)
 set(LINEAIRDB_PLUGIN_DYNAMIC "ha_lineairdb")
-set(LINEAIRDB_SOURCES ha_lineairdb.cc)
+set(LINEAIRDB_SOURCES ha_lineairdb.cc ha_lineairdb_handler_miscs.cc)
 add_definitions(-DMYSQL_SERVER)
 
 if(WITH_LINEAIRDB_STORAGE_ENGINE AND NOT WITHOUT_LINEAIRDB_STORAGE_ENGINE)

--- a/ha_lineairdb.cc
+++ b/ha_lineairdb.cc
@@ -277,8 +277,10 @@ int ha_lineairdb::index_read_map(uchar* buf, const uchar* key, key_part_map,
     get_db()->EndTransaction(tx, [&](auto s) { status = s; });
     return HA_ERR_END_OF_FILE;
   }
-  if (store_read_result_in_field(buf, read_buffer.first, read_buffer.second))
+  if (set_fields_from_lineairdb(buf, read_buffer.first, read_buffer.second)) {
+    tx.Abort();
     return HA_ERR_OUT_OF_MEM;
+  }
   get_db()->EndTransaction(tx, [&](auto s) { status = s; });
   return 0;
 }
@@ -422,8 +424,10 @@ read_from_lineairdb:
     current_position++;
     goto read_from_lineairdb;
   }
-  if (store_read_result_in_field(buf, read_buffer.first, read_buffer.second))
+  if (set_fields_from_lineairdb(buf, read_buffer.first, read_buffer.second)) {
+    tx.Abort();
     return HA_ERR_OUT_OF_MEM;
+  }
   get_db()->EndTransaction(tx, [&](auto s) { status = s; });
   current_position++;
   DBUG_RETURN(0);

--- a/ha_lineairdb.h
+++ b/ha_lineairdb.h
@@ -276,7 +276,8 @@ class ha_lineairdb : public handler {
   void set_current_key(const uchar* key = nullptr);
   void set_write_buffer();
   bool is_primary_key_exists();
-  bool set_fields_from_lineairdb(uchar* buf, LineairDB::Transaction& tx);
+  int set_fields_from_lineairdb(uchar* buf, const std::byte* const read_buf,
+                                const size_t read_buf_size);
 };
 
 #endif /* HA_LINEAIRDB_H */

--- a/ha_lineairdb_handler_miscs.cc
+++ b/ha_lineairdb_handler_miscs.cc
@@ -1,0 +1,228 @@
+
+#include "storage/lineairdb/ha_lineairdb.h"
+
+#include "my_dbug.h"
+#include "mysql/plugin.h"
+#include "sql/field.h"
+#include "sql/sql_class.h"
+#include "sql/sql_plugin.h"
+#include "sql/table.h"
+#include "typelib.h"
+
+static MYSQL_THDVAR_STR(last_create_thdvar, PLUGIN_VAR_MEMALLOC, nullptr,
+                        nullptr, nullptr, nullptr);
+
+static MYSQL_THDVAR_UINT(create_count_thdvar, 0, nullptr, nullptr, nullptr, 0,
+                         0, 1000, 0);
+
+/*
+  List of all system tables specific to the SE.
+  Array element would look like below,
+     { "<database_name>", "<system table name>" },
+  The last element MUST be,
+     { (const char*)NULL, (const char*)NULL }
+
+  This array is optional, so every SE need not implement it.
+*/
+static st_handler_tablename ha_lineairdb_system_tables[] = {
+    {(const char*)nullptr, (const char*)nullptr}};
+
+/**
+  @brief Check if the given db.tablename is a system table for this SE.
+
+  @param db                         Database name to check.
+  @param table_name                 table name to check.
+  @param is_sql_layer_system_table  if the supplied db.table_name is a SQL
+                                    layer system table.
+
+  @retval true   Given db.table_name is supported system table.
+  @retval false  Given db.table_name is not a supported system table.
+*/
+static bool lineairdb_is_supported_system_table(
+    const char* db, const char* table_name, bool is_sql_layer_system_table) {
+  st_handler_tablename* systab;
+
+  // Does this SE support "ALL" SQL layer system tables ?
+  if (is_sql_layer_system_table) return false;
+
+  // Check if this is SE layer system tables
+  systab = ha_lineairdb_system_tables;
+  while (systab && systab->db) {
+    if (systab->db == db && strcmp(systab->tablename, table_name) == 0)
+      return true;
+    systab++;
+  }
+
+  return false;
+}
+
+
+struct lineairdb_vars_t {
+  ulong var1;
+  double var2;
+  char var3[64];
+  bool var4;
+  bool var5;
+  ulong var6;
+};
+
+static handler* lineairdb_create_handler(handlerton* hton, TABLE_SHARE* table,
+                                         bool partitioned, MEM_ROOT* mem_root);
+
+handlerton* lineairdb_hton;
+
+/* Interface to mysqld, to check system tables supported by SE */
+static bool lineairdb_is_supported_system_table(const char* db,
+                                                const char* table_name,
+                                                bool is_sql_layer_system_table);
+
+static handler* lineairdb_create_handler(handlerton* hton, TABLE_SHARE* table,
+                                         bool, MEM_ROOT* mem_root) {
+  return new (mem_root) ha_lineairdb(hton, table);
+}
+
+static int lineairdb_init_func(void* p) {
+  DBUG_TRACE;
+
+  lineairdb_hton         = (handlerton*)p;
+  lineairdb_hton->state  = SHOW_OPTION_YES;
+  lineairdb_hton->create = lineairdb_create_handler;
+  lineairdb_hton->flags  = HTON_CAN_RECREATE;
+  lineairdb_hton->is_supported_system_table =
+      lineairdb_is_supported_system_table;
+  lineairdb_hton->db_type = DB_TYPE_UNKNOWN;
+
+  return 0;
+}
+
+struct st_mysql_storage_engine lineairdb_storage_engine = {
+    MYSQL_HANDLERTON_INTERFACE_VERSION};
+
+static ulong srv_enum_var               = 0;
+static ulong srv_ulong_var              = 0;
+static double srv_double_var            = 0;
+static int srv_signed_int_var           = 0;
+static long srv_signed_long_var         = 0;
+static longlong srv_signed_longlong_var = 0;
+
+const char* enum_var_names[] = {"e1", "e2", NullS};
+
+TYPELIB enum_var_typelib = {array_elements(enum_var_names) - 1,
+                            "enum_var_typelib", enum_var_names, nullptr};
+
+static MYSQL_SYSVAR_ENUM(enum_var,                        // name
+                         srv_enum_var,                    // varname
+                         PLUGIN_VAR_RQCMDARG,             // opt
+                         "Sample ENUM system variable.",  // comment
+                         nullptr,                         // check
+                         nullptr,                         // update
+                         0,                               // def
+                         &enum_var_typelib);              // typelib
+
+static MYSQL_SYSVAR_ULONG(ulong_var, srv_ulong_var, PLUGIN_VAR_RQCMDARG,
+                          "0..1000", nullptr, nullptr, 8, 0, 1000, 0);
+
+static MYSQL_SYSVAR_DOUBLE(double_var, srv_double_var, PLUGIN_VAR_RQCMDARG,
+                           "0.500000..1000.500000", nullptr, nullptr, 8.5, 0.5,
+                           1000.5,
+                           0);  // reserved always 0
+
+static MYSQL_THDVAR_DOUBLE(double_thdvar, PLUGIN_VAR_RQCMDARG,
+                           "0.500000..1000.500000", nullptr, nullptr, 8.5, 0.5,
+                           1000.5, 0);
+
+static MYSQL_SYSVAR_INT(signed_int_var, srv_signed_int_var, PLUGIN_VAR_RQCMDARG,
+                        "INT_MIN..INT_MAX", nullptr, nullptr, -10, INT_MIN,
+                        INT_MAX, 0);
+
+static MYSQL_THDVAR_INT(signed_int_thdvar, PLUGIN_VAR_RQCMDARG,
+                        "INT_MIN..INT_MAX", nullptr, nullptr, -10, INT_MIN,
+                        INT_MAX, 0);
+
+static MYSQL_SYSVAR_LONG(signed_long_var, srv_signed_long_var,
+                         PLUGIN_VAR_RQCMDARG, "LONG_MIN..LONG_MAX", nullptr,
+                         nullptr, -10, LONG_MIN, LONG_MAX, 0);
+
+static MYSQL_THDVAR_LONG(signed_long_thdvar, PLUGIN_VAR_RQCMDARG,
+                         "LONG_MIN..LONG_MAX", nullptr, nullptr, -10, LONG_MIN,
+                         LONG_MAX, 0);
+
+static MYSQL_SYSVAR_LONGLONG(signed_longlong_var, srv_signed_longlong_var,
+                             PLUGIN_VAR_RQCMDARG, "LLONG_MIN..LLONG_MAX",
+                             nullptr, nullptr, -10, LLONG_MIN, LLONG_MAX, 0);
+
+static MYSQL_THDVAR_LONGLONG(signed_longlong_thdvar, PLUGIN_VAR_RQCMDARG,
+                             "LLONG_MIN..LLONG_MAX", nullptr, nullptr, -10,
+                             LLONG_MIN, LLONG_MAX, 0);
+
+static SYS_VAR* lineairdb_system_variables[] = {
+    MYSQL_SYSVAR(enum_var),
+    MYSQL_SYSVAR(ulong_var),
+    MYSQL_SYSVAR(double_var),
+    MYSQL_SYSVAR(double_thdvar),
+    MYSQL_SYSVAR(last_create_thdvar),
+    MYSQL_SYSVAR(create_count_thdvar),
+    MYSQL_SYSVAR(signed_int_var),
+    MYSQL_SYSVAR(signed_int_thdvar),
+    MYSQL_SYSVAR(signed_long_var),
+    MYSQL_SYSVAR(signed_long_thdvar),
+    MYSQL_SYSVAR(signed_longlong_var),
+    MYSQL_SYSVAR(signed_longlong_thdvar),
+    nullptr};
+
+// this is an lineairdb of SHOW_FUNC
+static int show_func_lineairdb(MYSQL_THD, SHOW_VAR* var, char* buf) {
+  var->type  = SHOW_CHAR;
+  var->value = buf;  // it's of SHOW_VAR_FUNC_BUFF_SIZE bytes
+  snprintf(buf, SHOW_VAR_FUNC_BUFF_SIZE,
+           "enum_var is %lu, ulong_var is %lu, "
+           "double_var is %f, signed_int_var is %d, "
+           "signed_long_var is %ld, signed_longlong_var is %lld",
+           srv_enum_var, srv_ulong_var, srv_double_var, srv_signed_int_var,
+           srv_signed_long_var, srv_signed_longlong_var);
+  return 0;
+}
+
+lineairdb_vars_t lineairdb_vars = {100,  20.01, "three hundred",
+                                   true, false, 8250};
+
+static SHOW_VAR show_status_lineairdb[] = {
+    {"var1", (char*)&lineairdb_vars.var1, SHOW_LONG, SHOW_SCOPE_GLOBAL},
+    {"var2", (char*)&lineairdb_vars.var2, SHOW_DOUBLE, SHOW_SCOPE_GLOBAL},
+    {nullptr, nullptr, SHOW_UNDEF,
+     SHOW_SCOPE_UNDEF}  // null terminator required
+};
+
+static SHOW_VAR show_array_lineairdb[] = {
+    {"array", (char*)show_status_lineairdb, SHOW_ARRAY, SHOW_SCOPE_GLOBAL},
+    {"var3", (char*)&lineairdb_vars.var3, SHOW_CHAR, SHOW_SCOPE_GLOBAL},
+    {"var4", (char*)&lineairdb_vars.var4, SHOW_BOOL, SHOW_SCOPE_GLOBAL},
+    {nullptr, nullptr, SHOW_UNDEF, SHOW_SCOPE_UNDEF}};
+
+static SHOW_VAR func_status[] = {
+    {"lineairdb_func_lineairdb", (char*)show_func_lineairdb, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"lineairdb_status_var5", (char*)&lineairdb_vars.var5, SHOW_BOOL,
+     SHOW_SCOPE_GLOBAL},
+    {"lineairdb_status_var6", (char*)&lineairdb_vars.var6, SHOW_LONG,
+     SHOW_SCOPE_GLOBAL},
+    {"lineairdb_status", (char*)show_array_lineairdb, SHOW_ARRAY,
+     SHOW_SCOPE_GLOBAL},
+    {nullptr, nullptr, SHOW_UNDEF, SHOW_SCOPE_UNDEF}};
+
+mysql_declare_plugin(lineairdb){
+    MYSQL_STORAGE_ENGINE_PLUGIN,
+    &lineairdb_storage_engine,
+    "LINEAIRDB",
+    PLUGIN_AUTHOR_ORACLE,
+    "LineairDB storage engine",
+    PLUGIN_LICENSE_GPL,
+    lineairdb_init_func, /* Plugin Init */
+    nullptr,             /* Plugin check uninstall */
+    nullptr,             /* Plugin Deinit */
+    0x0001 /* 0.1 */,
+    func_status,                /* status variables */
+    lineairdb_system_variables, /* system variables */
+    nullptr,                    /* config options */
+    0,                          /* flags */
+} mysql_declare_plugin_end;


### PR DESCRIPTION
* separate `ha_lineairdb.cc` to two `.cc` files to distinct static variables and override methods
* define the following private methods to make DRY.
   ```
    std::string get_current_key();
    void set_current_key(const uchar* key = nullptr);
    void set_write_buffer();
    bool is_primary_key_exists();
    bool set_fields_from_lineairdb(uchar* buf,  LineairDB::Transaction& tx);
  ```
* use `{setup,teardown}_file` keyword in test.bats to reuse mysql daemon.